### PR TITLE
fix: remove `files rsync` option `--compress` when transfer local to local

### DIFF
--- a/cmd/files/rsync.go
+++ b/cmd/files/rsync.go
@@ -191,6 +191,12 @@ func remoteTransferFile(cmd *cobra.Command, args []string) {
 		options = append(options, rsyncOptCopyDir)
 	}
 
+	if !isSrcRemote && !isDestRemote { // no compress on local to local transfer
+		options = goe.NewIEnumerable(options...).Where(func(option string) bool {
+			return !strings.EqualFold(option, "--compress")
+		}).ToArray()
+	}
+
 	logFile, _ := cmd.Flags().GetString(flagLogFile)
 	if len(logFile) > 0 {
 		duplicated := goe.NewIEnumerable[string](options...).AnyBy(func(flag string) bool {

--- a/constants/varcons.go
+++ b/constants/varcons.go
@@ -4,6 +4,6 @@ package constants
 
 //goland:noinspection GoSnakeCaseUsage
 var (
-	VERSION           = "0.8.1"
+	VERSION           = "0.8.2"
 	BUILD_FROM_SOURCE = ""
 )


### PR DESCRIPTION
Closes #37 